### PR TITLE
[FEAT] 앱 부품 조회 시 지점 부품 정보 추가

### DIFF
--- a/src/main/java/com/stockmate/parts/api/parts/controller/StoreController.java
+++ b/src/main/java/com/stockmate/parts/api/parts/controller/StoreController.java
@@ -1,8 +1,8 @@
 package com.stockmate.parts.api.parts.controller;
 
 import com.stockmate.parts.api.parts.dto.common.PageResponseDto;
-import com.stockmate.parts.api.parts.dto.parts.PartsDto;
-import com.stockmate.parts.api.parts.service.InventoryService;
+import com.stockmate.parts.api.parts.dto.store.StorePartsDto;
+import com.stockmate.parts.api.parts.service.StoreService;
 import com.stockmate.parts.common.config.swagger.security.SecurityUser;
 import com.stockmate.parts.common.response.ApiResponse;
 import com.stockmate.parts.common.response.SuccessStatus;
@@ -19,13 +19,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/store")
 @RequiredArgsConstructor
-public class InventoryController {
+public class StoreController {
 
-    private final InventoryService inventoryService;
+    private final StoreService storeService;
 
     @Operation(summary = "지점 재고조회")
     @GetMapping("/search")
-    public ResponseEntity<ApiResponse<PageResponseDto<PartsDto>>> getInventories(
+    public ResponseEntity<ApiResponse<PageResponseDto<StorePartsDto>>> getInventories(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) List<String> categoryName,
@@ -34,7 +34,7 @@ public class InventoryController {
             @AuthenticationPrincipal SecurityUser securityUser
     ) {
         long userId = securityUser.getMemberId();
-        var data = inventoryService.searchParts(userId, categoryName, trim, model, page, size);
+        var data = storeService.searchParts(userId, categoryName, trim, model, page, size);
         return ApiResponse.success(SuccessStatus.INVENTORY_FETCH_SUCCESS, data);
     }
 

--- a/src/main/java/com/stockmate/parts/api/parts/dto/store/StoreInventoryDto.java
+++ b/src/main/java/com/stockmate/parts/api/parts/dto/store/StoreInventoryDto.java
@@ -1,4 +1,4 @@
-package com.stockmate.parts.api.parts.dto;
+package com.stockmate.parts.api.parts.dto.store;
 
 import com.stockmate.parts.api.parts.entity.Parts;
 import com.stockmate.parts.api.parts.entity.StoreInventory;
@@ -11,20 +11,20 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class InventoryItemDto {
+public class StoreInventoryDto {
     private Long partId;
     private String partName;
     private String image;
     private Long price;
-    private Long amount;
-    private Long limitAmount;
+    private Integer amount;
+    private Integer limitAmount;
     private Boolean underLimit;
     private LocalDateTime updatedAt;
 
-    public static InventoryItemDto of(StoreInventory si) {
+    public static StoreInventoryDto of(StoreInventory si) {
         Parts p = si.getPart();
         boolean under = si.getLimitAmount() != null && si.getAmount() < si.getLimitAmount();
-        return InventoryItemDto.builder()
+        return StoreInventoryDto.builder()
                 .partId(p.getId())
                 .partName(p.getName())
                 .image(p.getImage())

--- a/src/main/java/com/stockmate/parts/api/parts/dto/store/StorePartsDto.java
+++ b/src/main/java/com/stockmate/parts/api/parts/dto/store/StorePartsDto.java
@@ -1,0 +1,49 @@
+package com.stockmate.parts.api.parts.dto.store;
+
+import com.stockmate.parts.api.parts.entity.Parts;
+import com.stockmate.parts.api.parts.entity.StoreInventory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class StorePartsDto {
+    private Long id;
+    private String name;
+    private Long price;
+    private String image;
+    private String trim;
+    private String model;
+    private Integer category;
+    private String korName;
+    private String engName;
+    private String categoryName;
+    private Integer stock;
+    private Integer amount;
+    private Integer limitAmount;
+    private Boolean isLack;
+
+    public static StorePartsDto of(Parts p, StoreInventory si, Boolean isLack) {
+        return StorePartsDto.builder()
+                .id(p.getId())
+                .name(p.getName())
+                .price(p.getPrice())
+                .image(p.getImage())
+                .image(p.getImage())
+                .trim(p.getTrim())
+                .model(p.getModel())
+                .category(p.getCategory())
+                .korName(p.getKorName())
+                .engName(p.getEngName())
+                .categoryName(p.getCategoryName())
+                .stock(p.getAmount())
+                .amount(si.getAmount())
+                .limitAmount(si.getLimitAmount())
+                .isLack(isLack)
+                .build();
+    }
+}

--- a/src/main/java/com/stockmate/parts/api/parts/entity/StoreInventory.java
+++ b/src/main/java/com/stockmate/parts/api/parts/entity/StoreInventory.java
@@ -16,10 +16,10 @@ public class StoreInventory extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
-    private Long amount;       // 현재 수량
+    private Integer amount;       // 현재 수량
 
     @Column(name = "limit_amount")
-    private Long limitAmount;  // 최소 필요 수량(부족 판단 기준)
+    private Integer limitAmount;  // 최소 필요 수량(부족 판단 기준)
 
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "part_id", nullable = false)
     private Parts part;

--- a/src/main/java/com/stockmate/parts/api/parts/repository/StoreRepository.java
+++ b/src/main/java/com/stockmate/parts/api/parts/repository/StoreRepository.java
@@ -1,6 +1,5 @@
 package com.stockmate.parts.api.parts.repository;
 
-import com.stockmate.parts.api.parts.entity.Parts;
 import com.stockmate.parts.api.parts.entity.StoreInventory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,11 +9,11 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
-public interface StoreInventoryRepository extends JpaRepository<StoreInventory, Long> {
+public interface StoreRepository extends JpaRepository<StoreInventory, Long> {
 
     // 지점 부품 검색
     @Query("""
-    select p
+    select p, si, CASE WHEN si.amount < si.limitAmount Then true ELSE false END
     from StoreInventory si
     join si.part p
     where si.userId = :userId
@@ -22,7 +21,7 @@ public interface StoreInventoryRepository extends JpaRepository<StoreInventory, 
         and (:trims is null or p.trim in :trims)
         and (:models is null or p.model in :models)
     """)
-    Page<Parts> searchParts(
+    Page<Object[]> searchParts(
             @Param("userId") Long userId,
             @Param("categoryNames") List<String> categoryNames,
             @Param("trims") List<String> trims,


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #38 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
지점 부품 조회 시 부품 정보 추가

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 부품 검색 결과에 매장 재고 정보와 부족 여부 플래그가 포함됩니다.
  - 응답에 부품 기본 정보와 함께 매장 보유 수량, 한계 수량, 재고 수량 등이 제공됩니다.

- 리팩터
  - 도메인 용어를 “인벤토리” 중심에서 “스토어/매장” 중심으로 정비했습니다.
  - 검색 응답 구조를 간소화하고 매장 관점의 정보로 재구성했습니다.
  - 수량 관련 숫자 타입을 정수 기반으로 일원화하여 일관성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->