### PR TITLE
[FEAT] 파츠 여러개 상세 조회

### DIFF
--- a/src/main/java/com/stockmate/parts/api/parts/controller/PartsController.java
+++ b/src/main/java/com/stockmate/parts/api/parts/controller/PartsController.java
@@ -25,9 +25,9 @@ public class PartsController {
     @Operation(summary = "부품 상세 조회")
     @PostMapping("/detail")
     public ResponseEntity<ApiResponse<List<PartsDto>>> getPartDetail(
-            @RequestBody List<Long> partList
+            @RequestBody List<Long> partIds
     ) {
-        var data = partsService.getPartDetail(partList);
+        var data = partsService.getPartDetail(partIds);
         return ApiResponse.success(SuccessStatus.PARTS_DETAIL_SUCCESS, data);
     }
 

--- a/src/main/java/com/stockmate/parts/api/parts/repository/PartsRepository.java
+++ b/src/main/java/com/stockmate/parts/api/parts/repository/PartsRepository.java
@@ -33,9 +33,6 @@ public interface PartsRepository extends JpaRepository<Parts, Long> {
             Pageable pageable
     );
 
-    // id로 검색
-    Optional<Parts> findById(Long id);
-
     // 부족 재고 조회
     Page<Parts> findByAmountLessThanEqual(Integer amount, Pageable pageable);
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #43

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
파츠 다중 조회

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 부품 상세 일괄 조회 지원: 여러 부품 ID를 요청 본문으로 보내 한 번에 상세 정보를 받을 수 있습니다.
  - 재고 확인 응답 개선: 각 항목에 availableStock(가용 재고) 정보가 포함됩니다.
- **변경 사항**
  - 부품 상세 조회 API가 본문 기반 POST로 전환되었고 응답이 단일 항목에서 목록으로 변경되었습니다.
  - 요청한 일부 ID가 존재하지 않으면 오류로 응답합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->