### PR TITLE
[FEAT] 카테고리별 부족 부품 갯수

### DIFF
--- a/src/main/java/com/stockmate/parts/api/parts/controller/StoreController.java
+++ b/src/main/java/com/stockmate/parts/api/parts/controller/StoreController.java
@@ -1,6 +1,7 @@
 package com.stockmate.parts.api.parts.controller;
 
 import com.stockmate.parts.api.parts.dto.common.PageResponseDto;
+import com.stockmate.parts.api.parts.dto.store.CategoryLackCountDto;
 import com.stockmate.parts.api.parts.dto.store.StorePartsDto;
 import com.stockmate.parts.api.parts.service.StoreService;
 import com.stockmate.parts.common.config.swagger.security.SecurityUser;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "store", description = "지점 재고 관련 API 입니다.")
+@Tag(name = "Store", description = "지점 재고 관련 API 입니다.")
 @RestController
 @RequestMapping("/api/v1/store")
 @RequiredArgsConstructor
@@ -23,7 +24,7 @@ public class StoreController {
 
     private final StoreService storeService;
 
-    @Operation(summary = "지점 재고조회")
+    @Operation(summary = "지점 재고 조회")
     @GetMapping("/search")
     public ResponseEntity<ApiResponse<PageResponseDto<StorePartsDto>>> getInventories(
             @RequestParam(defaultValue = "0") int page,
@@ -35,10 +36,10 @@ public class StoreController {
     ) {
         long userId = securityUser.getMemberId();
         var data = storeService.searchParts(userId, categoryName, trim, model, page, size);
-        return ApiResponse.success(SuccessStatus.INVENTORY_FETCH_SUCCESS, data);
+        return ApiResponse.success(SuccessStatus.STORE_SEARCH_SUCCESS, data);
     }
 
-    @Operation(summary = "카테고리별 부족재고 조회")
+    @Operation(summary = "카테고리별 부족 재고 조회")
     @GetMapping("/under-limit")
     public ResponseEntity<ApiResponse<PageResponseDto<StorePartsDto>>> getUnderLimitInventories(
             @RequestParam(required = false) String categoryName,
@@ -48,7 +49,17 @@ public class StoreController {
     ) {
         long userId = securityUser.getMemberId();
         var data = storeService.getUnderLimit(userId, categoryName, page, size);
-        return ApiResponse.success(SuccessStatus.INVENTORY_UNDER_LIMIT_SUCCESS, data);
+        return ApiResponse.success(SuccessStatus.STORE_UNDER_LIMIT_SUCCESS, data);
+    }
+
+    @Operation(summary = "카테고리별 부족 재고 갯수 조회")
+    @GetMapping("/lack-count")
+    public ResponseEntity<ApiResponse<List<CategoryLackCountDto>>> getCategoryLackCount(
+            @AuthenticationPrincipal SecurityUser securityUser
+    ) {
+        long userId = securityUser.getMemberId();
+        var data = storeService.getCategoryLackCount(userId);
+        return ApiResponse.success(SuccessStatus.STORE_CATEGORY_LACK_COUNT_SUCCESS, data);
     }
 //
 //    @Operation(summary = "부품 분포 요약-임시 API")

--- a/src/main/java/com/stockmate/parts/api/parts/dto/store/CategoryLackCountDto.java
+++ b/src/main/java/com/stockmate/parts/api/parts/dto/store/CategoryLackCountDto.java
@@ -1,0 +1,14 @@
+package com.stockmate.parts.api.parts.dto.store;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryLackCountDto {
+    private String categoryName;
+    private Integer count;
+}

--- a/src/main/java/com/stockmate/parts/api/parts/repository/StoreRepository.java
+++ b/src/main/java/com/stockmate/parts/api/parts/repository/StoreRepository.java
@@ -1,11 +1,10 @@
 package com.stockmate.parts.api.parts.repository;
 
-import com.stockmate.parts.api.parts.dto.store.StorePartsDto;
+import com.stockmate.parts.api.parts.dto.store.CategoryLackCountDto;
 import com.stockmate.parts.api.parts.entity.StoreInventory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -45,15 +44,17 @@ public interface StoreRepository extends JpaRepository<StoreInventory, Long> {
             Pageable pageable
     );
 
-    // 본사 특정 부품 총 수량
-//    @Query("""
-//        select sum(si.amount)
-//        from StoreInventory si
-//        where si.part.id = :partId and si.userId = :userId
-//        """)
-//    Long sumAmountByPartAndStore(@Param("partId") Long partId,
-//                                 @Param("userId") Long userId);
-//
+    // 카테고리별 부족 부품 갯수
+    @Query("""
+        select p.categoryName, count(si)
+        from StoreInventory si
+        join si.part p
+        where si.userId = :userId
+            and(si.amount < si.limitAmount)
+        group by p.categoryName
+    """)
+    List<Object[]> countLackPartsByCategory(Long userId);
+
 //    // 특정 부품이 부족재고인 지점 개수
 //    @Query("""
 //        select count(si) from StoreInventory si
@@ -86,26 +87,5 @@ public interface StoreRepository extends JpaRepository<StoreInventory, Long> {
 //    )
 //    Page<AnalysisRowDto> analyzeAll(Pageable pageable,
 //                                    @Param("q") String q);
-//
-//
-//    // 발주 가능 여부
-//    @Query("select p.amount from Parts p where p.id = :id")
-//    Integer findAmountByPartId(@Param("id") Long id);
-
-//    @Query("""
-//      select new com.stockmate.parts.api.parts.dto.CategorySumProjection(
-//        bc.id,
-//        bc.name,
-//        sum(si.amount)
-//      )
-//      from StoreInventory si
-//        join si.part p
-//        left join p.midCate mc
-//        left join mc.bigCate bc
-//      where (:userId is null or si.userId = :userId)
-//      group by bc.id, bc.name
-//      order by sum(si.amount) desc
-//    """)
-//    List<CategorySumProjection> sumByBigCategory(@Param("userId") Long userId);
 }
 

--- a/src/main/java/com/stockmate/parts/api/parts/service/StoreService.java
+++ b/src/main/java/com/stockmate/parts/api/parts/service/StoreService.java
@@ -1,6 +1,7 @@
 package com.stockmate.parts.api.parts.service;
 
 import com.stockmate.parts.api.parts.dto.common.PageResponseDto;
+import com.stockmate.parts.api.parts.dto.store.CategoryLackCountDto;
 import com.stockmate.parts.api.parts.dto.store.StorePartsDto;
 import com.stockmate.parts.api.parts.entity.Parts;
 import com.stockmate.parts.api.parts.entity.StoreInventory;
@@ -75,12 +76,29 @@ public class StoreService {
             Parts part = (Parts) row[0];
             StoreInventory storeInventory = (StoreInventory) row[1];
             Boolean isLack = row[2] == null ? false : (Boolean) row[2];
+            log.info("storeInventory : {}, isLack : {]", storeInventory, isLack);
             return StorePartsDto.of(part, storeInventory, isLack);
         });
 
         log.info("[StoreService] 🏁 getUnderLimit() 종료");
         return PageResponseDto.from(mapped);
     }
+
+    // 카테고리별 부족 제품 갯수
+    public List<CategoryLackCountDto> getCategoryLackCount(Long userId) {
+        log.info("[StoreService] 🔍 카테고리별 부족 재고 수 조회 시작 | userId={}", userId);
+
+        if (userId == null || userId <= 0) {
+            log.error("[StoreService] ❌ 잘못된 사용자 ID: {}", userId);
+            throw new BadRequestException("잘못된 사용자 ID입니다.");
+        }
+
+        List<Object[]> result = storeRepository.countLackPartsByCategory(userId);
+
+        log.info("[StoreService] ✅ 카테고리별 부족 재고 수 조회 완료 | totalCategories={}", result.size());
+        return result.stream()
+                .map(row -> new CategoryLackCountDto((String) row[0], ((Long) row[1]).intValue()))
+                .toList();    }
 
 //    @Value("${stockmate.export.tmp-dir:/tmp/stockmate}")
 //    private String exportTmpDir = "/tmp/stockmate";

--- a/src/main/java/com/stockmate/parts/common/response/SuccessStatus.java
+++ b/src/main/java/com/stockmate/parts/common/response/SuccessStatus.java
@@ -16,14 +16,17 @@ public enum SuccessStatus {
     SEND_LOGIN_SUCCESS(HttpStatus.OK,"로그인 성공"),
     SEND_REISSUE_TOKEN_SUCCESS(HttpStatus.OK,"토큰 재발급 성공"),
     SEND_HEALTH_CHECK_SUCCESS(HttpStatus.OK,"서버 상태 체크 성공"),
-    // Inventory (재고) 관련
-    INVENTORY_FETCH_SUCCESS(HttpStatus.OK, "재고 조회 성공"),
-    INVENTORY_SEARCH_SUCCESS(HttpStatus.OK, "재고 검색 성공"),
-    INVENTORY_UNDER_LIMIT_SUCCESS(HttpStatus.OK, "부족 재고 조회 성공"),
+
+    // 지점 관련
+    STORE_ANALYSIS_SUCCESS(HttpStatus.OK, "재고 분석 조회 성공"),
+    STORE_EXPORT_SUCCESS(HttpStatus.OK, "재고 분석 내보내기 성공"),
+    STORE_DASHBOARD_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리별 재고 비중 조회 성공"),
+    STORE_SEARCH_SUCCESS(HttpStatus.OK, "지점 재고 조회 성공"),
+    STORE_UNDER_LIMIT_SUCCESS(HttpStatus.OK, "지점 부족 재고 조회 성공"),
+    STORE_CATEGORY_LACK_COUNT_SUCCESS(HttpStatus.OK, "카테고리별 부족 재고 조회 성공"),
+
+    // 본사 재고 관련
     PART_DISTRIBUTION_SUCCESS(HttpStatus.OK, "부품 분포 조회 성공"),
-    INVENTORY_ANALYSIS_SUCCESS(HttpStatus.OK, "재고 분석 조회 성공"),
-    INVENTORY_EXPORT_SUCCESS(HttpStatus.OK, "재고 분석 내보내기 성공"),
-    INVENTORY_DASHBOARD_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리별 재고 비중 조회 성공"),
     PARTS_STOCK_CHECK_SUCCESS(HttpStatus.OK, "주문 가능 여부 조회 성공"),
     PARTS_DETAIL_SUCCESS(HttpStatus.OK, "부품 상세 조회 성공"),
     PARTS_LIST_SUCCESS(HttpStatus.OK, "부품 목록 조회 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #46

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
카테고리별 부족 부품 갯수 조회

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 카테고리별 부족 재고 수를 조회하는 새 API 엔드포인트(/lack-count)를 추가하여 지점별 부족 항목 집계 목록을 제공합니다.
  - 카테고리별 부족 재고 수를 반환하는 응답 형태를 추가했습니다.
- 리팩터
  - 성공 응답 메시지를 스토어 중심으로 재정비하여 지점 관련 응답 상태명을 명확히 했습니다.
- 문서/표현
  - 일부 API 설명 문구를 가독성 있게 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->