### PR TITLE
[FEAT] 대시보드 창고 별 재고 조회 기능 구현

### DIFF
--- a/src/main/java/com/stockmate/parts/api/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/stockmate/parts/api/dashboard/controller/DashboardController.java
@@ -1,0 +1,37 @@
+package com.stockmate.parts.api.dashboard.controller;
+
+import com.stockmate.parts.api.dashboard.dto.WarehouseInventoryRatioResponseDTO;
+import com.stockmate.parts.api.dashboard.service.DashboardService;
+import com.stockmate.parts.common.response.ApiResponse;
+import com.stockmate.parts.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Dashboard", description = "대시보드 관련 API 입니다.")
+@RestController
+@RequestMapping("/api/v1/parts/dashboard")
+@RequiredArgsConstructor
+@Slf4j
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @Operation(
+            summary = "창고별 재고 비중 조회",
+            description = "A, B, C, D, E 창고별 재고 수량과 비중(%)을 조회합니다."
+    )
+    @GetMapping("/warehouse-ratio")
+    public ResponseEntity<ApiResponse<WarehouseInventoryRatioResponseDTO>> getWarehouseInventoryRatio() {
+        log.info("창고별 재고 비중 조회 요청");
+        WarehouseInventoryRatioResponseDTO response = dashboardService.getWarehouseInventoryRatio();
+        log.info("창고별 재고 비중 조회 완료 - 창고 수: {}", response.getWarehouses().size());
+        return ApiResponse.success(SuccessStatus.PARTS_WAREHOUSE_RATIO_SUCCESS, response);
+    }
+}
+

--- a/src/main/java/com/stockmate/parts/api/dashboard/dto/WarehouseInventoryRatioResponseDTO.java
+++ b/src/main/java/com/stockmate/parts/api/dashboard/dto/WarehouseInventoryRatioResponseDTO.java
@@ -1,0 +1,27 @@
+package com.stockmate.parts.api.dashboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WarehouseInventoryRatioResponseDTO {
+    private List<WarehouseRatio> warehouses;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class WarehouseRatio {
+        private String warehouse;     // 창고 코드 (A, B, C, D, E)
+        private Long totalQuantity;   // 총 재고 수량
+        private Double percentage;     // 비중 (%)
+    }
+}
+

--- a/src/main/java/com/stockmate/parts/api/dashboard/service/DashboardService.java
+++ b/src/main/java/com/stockmate/parts/api/dashboard/service/DashboardService.java
@@ -1,0 +1,59 @@
+package com.stockmate.parts.api.dashboard.service;
+
+import com.stockmate.parts.api.dashboard.dto.WarehouseInventoryRatioResponseDTO;
+import com.stockmate.parts.api.parts.repository.PartsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class DashboardService {
+
+    private final PartsRepository partsRepository;
+
+    // 창고별 재고 비중 조회 location 첫 글자(A, B, C, D, E)로 창고를 구분하여 재고 수량과 비중을 계산
+    public WarehouseInventoryRatioResponseDTO getWarehouseInventoryRatio() {
+        log.info("[DashboardService] 🔍 창고별 재고 비중 조회 시작");
+
+        List<Object[]> result = partsRepository.getWarehouseInventoryRatio();
+
+        // 전체 재고 수량 계산
+        long totalQuantity = result.stream()
+                .mapToLong(row -> ((Number) row[1]).longValue())
+                .sum();
+
+        log.info("[DashboardService] 전체 재고 수량: {}", totalQuantity);
+
+        // 비율 계산
+        List<WarehouseInventoryRatioResponseDTO.WarehouseRatio> warehouseRatios = new ArrayList<>();
+        
+        for (Object[] row : result) {
+            String warehouse = (String) row[0];
+            Long quantity = ((Number) row[1]).longValue();
+            
+            double percentage = totalQuantity > 0 
+                    ? (quantity * 100.0 / totalQuantity) 
+                    : 0.0;
+            
+            warehouseRatios.add(WarehouseInventoryRatioResponseDTO.WarehouseRatio.builder()
+                    .warehouse(warehouse)
+                    .totalQuantity(quantity)
+                    .percentage(Math.round(percentage * 100.0) / 100.0) // 소수점 둘째 자리까지
+                    .build());
+        }
+
+        log.info("[DashboardService] 🏁 창고별 재고 비중 조회 완료 | 창고 수: {}", warehouseRatios.size());
+
+        return WarehouseInventoryRatioResponseDTO.builder()
+                .warehouses(warehouseRatios)
+                .build();
+    }
+}
+

--- a/src/main/java/com/stockmate/parts/api/parts/repository/PartsRepository.java
+++ b/src/main/java/com/stockmate/parts/api/parts/repository/PartsRepository.java
@@ -47,4 +47,17 @@ public interface PartsRepository extends JpaRepository<Parts, Long> {
             @Param("location") String location,
             @Param("floor") Integer floor
     );
+
+    // 창고별 재고 비중 조회 (location 첫 글자로 창고 구분, 재고 수량 합계)
+    @Query("""
+    SELECT SUBSTRING(p.location, 1, 1) as warehouse, 
+           COALESCE(SUM(p.amount), 0) as totalQuantity
+    FROM Parts p
+    WHERE p.location IS NOT NULL 
+      AND p.location != ''
+      AND SUBSTRING(p.location, 1, 1) IN ('A', 'B', 'C', 'D', 'E')
+    GROUP BY SUBSTRING(p.location, 1, 1)
+    ORDER BY SUBSTRING(p.location, 1, 1)
+    """)
+    List<Object[]> getWarehouseInventoryRatio();
 }

--- a/src/main/java/com/stockmate/parts/api/parts/service/StoreService.java
+++ b/src/main/java/com/stockmate/parts/api/parts/service/StoreService.java
@@ -323,6 +323,7 @@ public class StoreService {
         
         java.util.Map<String, Object> requestBody = new java.util.HashMap<>();
         requestBody.put("memberId", memberId);
+        requestBody.put("orderId", null); // 출고는 주문 ID 없음
         requestBody.put("orderNumber", null); // 출고는 주문 번호 없음
         requestBody.put("message", message);
         requestBody.put("status", "RELEASED");

--- a/src/main/java/com/stockmate/parts/common/response/SuccessStatus.java
+++ b/src/main/java/com/stockmate/parts/common/response/SuccessStatus.java
@@ -38,6 +38,7 @@ public enum SuccessStatus {
     PARTS_CATEGORY_AMOUNT(HttpStatus.OK, "카테고리별 재고 수 조회 성공"),
     PARTS_STOCK_DEDUCTION_SUCCESS(HttpStatus.OK, "재고 차감 성공"),
     PARTS_LOCATION_SUCCESS(HttpStatus.OK, "창고 구역 조회 성공"),
+    PARTS_WAREHOUSE_RATIO_SUCCESS(HttpStatus.OK, "창고별 재고 비중 조회 성공"),
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #84

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 대시보드 창고 별 재고 조회 기능을 구현하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 대시보드에서 창고별 재고 비중 정보를 조회할 수 있는 기능이 추가되었습니다. 각 창고의 재고 수량과 전체 대비 비중(%)을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->