### PR TITLE
[FEAT] 각 가맹점별 부품 갯수 조회 구현

### DIFF
--- a/src/main/java/com/stockmate/parts/api/parts/controller/PartsController.java
+++ b/src/main/java/com/stockmate/parts/api/parts/controller/PartsController.java
@@ -116,4 +116,15 @@ public class PartsController {
         
         return ApiResponse.success(SuccessStatus.PARTS_STOCK_DEDUCTION_SUCCESS, response);
     }
+
+    @Operation(summary = "부품 분포 조회 API", description = "부품 ID로 본사 보유 수량과 가맹점별 보유 수량을 조회합니다.")
+    @GetMapping("/distribution/{partId}")
+    public ResponseEntity<ApiResponse<PartDistributionResponseDTO>> getPartDistribution(
+            @PathVariable Long partId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        var data = partsService.getPartDistribution(partId, page, size);
+        return ApiResponse.success(SuccessStatus.PART_DISTRIBUTION_SUCCESS, data);
+    }
 }

--- a/src/main/java/com/stockmate/parts/api/parts/dto/common/PageResponseDto.java
+++ b/src/main/java/com/stockmate/parts/api/parts/dto/common/PageResponseDto.java
@@ -16,6 +16,10 @@ public class PageResponseDto<T> {
     private int size;
     private long totalElements;
     private int totalPages;
+    private boolean isLast;  // 마지막 페이지 여부
+    private boolean isFirst; // 첫 페이지 여부
+    private boolean hasNext; // 다음 페이지 존재 여부
+    private boolean hasPrevious; // 이전 페이지 존재 여부
 
     public static <T> PageResponseDto<T> from(Page<T> page) {
         return PageResponseDto.<T>builder()
@@ -24,6 +28,10 @@ public class PageResponseDto<T> {
                 .size(page.getSize())
                 .totalElements(page.getTotalElements())
                 .totalPages(page.getTotalPages())
+                .isLast(page.isLast())
+                .isFirst(page.isFirst())
+                .hasNext(page.hasNext())
+                .hasPrevious(page.hasPrevious())
                 .build();
     }
 }

--- a/src/main/java/com/stockmate/parts/api/parts/dto/parts/PartDistributionResponseDTO.java
+++ b/src/main/java/com/stockmate/parts/api/parts/dto/parts/PartDistributionResponseDTO.java
@@ -1,0 +1,29 @@
+package com.stockmate.parts.api.parts.dto.parts;
+
+import com.stockmate.parts.api.parts.dto.common.PageResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PartDistributionResponseDTO {
+    private Long partId;
+    private String partName;
+    private Integer headquartersQuantity;  // 본사 보유 수량
+    private PageResponseDto<StoreDistributionItem> stores;  // 가맹점별 보유 수량 (페이지네이션)
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StoreDistributionItem {
+        private Long userId;           // 가맹점 ID
+        private Integer quantity;      // 가맹점 보유 수량
+        private UserBatchResponseDTO storeInfo;  // 가맹점 정보 (User 서버에서 조회)
+    }
+}
+

--- a/src/main/java/com/stockmate/parts/api/parts/dto/parts/UserBatchApiResponse.java
+++ b/src/main/java/com/stockmate/parts/api/parts/dto/parts/UserBatchApiResponse.java
@@ -1,0 +1,20 @@
+package com.stockmate.parts.api.parts.dto.parts;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserBatchApiResponse {
+    private int status;
+    private boolean success;
+    private String message;
+    private List<UserBatchResponseDTO> data;
+}
+

--- a/src/main/java/com/stockmate/parts/api/parts/dto/parts/UserBatchRequestDTO.java
+++ b/src/main/java/com/stockmate/parts/api/parts/dto/parts/UserBatchRequestDTO.java
@@ -1,0 +1,17 @@
+package com.stockmate.parts.api.parts.dto.parts;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserBatchRequestDTO {
+    private List<Long> memberIds;
+}
+

--- a/src/main/java/com/stockmate/parts/api/parts/dto/parts/UserBatchResponseDTO.java
+++ b/src/main/java/com/stockmate/parts/api/parts/dto/parts/UserBatchResponseDTO.java
@@ -1,0 +1,25 @@
+package com.stockmate.parts.api.parts.dto.parts;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserBatchResponseDTO {
+    private Long id;
+    private Long memberId;
+    private String email;
+    private String owner;
+    private String address;
+    private String storeName;
+    private String businessNumber;
+    private String role;
+    private String verified;
+    private Double latitude;
+    private Double longitude;
+}
+

--- a/src/main/java/com/stockmate/parts/api/parts/repository/StoreRepository.java
+++ b/src/main/java/com/stockmate/parts/api/parts/repository/StoreRepository.java
@@ -90,6 +90,15 @@ public interface StoreRepository extends JpaRepository<StoreInventory, Long> {
     """)
     Optional<StoreInventory> findByUserIdAndPartCode(Long userId, String partCode);
 
+    // 부품 ID로 가맹점별 재고 조회 (페이지네이션)
+    @Query("""
+        SELECT si
+        FROM StoreInventory si
+        WHERE si.part.id = :partId
+        ORDER BY si.userId ASC
+    """)
+    Page<StoreInventory> findByPartId(@org.springframework.data.repository.query.Param("partId") Long partId, Pageable pageable);
+
 //    // 특정 부품이 부족재고인 지점 개수
 //    @Query("""
 //        select count(si) from StoreInventory si

--- a/src/main/java/com/stockmate/parts/api/parts/service/UserService.java
+++ b/src/main/java/com/stockmate/parts/api/parts/service/UserService.java
@@ -1,0 +1,84 @@
+package com.stockmate.parts.api.parts.service;
+
+import com.stockmate.parts.api.parts.dto.parts.UserBatchApiResponse;
+import com.stockmate.parts.api.parts.dto.parts.UserBatchRequestDTO;
+import com.stockmate.parts.api.parts.dto.parts.UserBatchResponseDTO;
+import com.stockmate.parts.common.exception.InternalServerException;
+import com.stockmate.parts.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+
+    private final WebClient webClient;
+
+    @Value("${user.server.url}")
+    private String userServerUrl;
+
+    public Map<Long, UserBatchResponseDTO> getUsersByMemberIds(List<Long> memberIds) {
+        log.info("사용자 정보 일괄 조회 요청 - Member IDs 수: {}", memberIds.size());
+
+        if (memberIds == null || memberIds.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        try {
+            UserBatchRequestDTO requestDTO = UserBatchRequestDTO.builder()
+                    .memberIds(memberIds)
+                    .build();
+
+            UserBatchApiResponse response = webClient.post()
+                    .uri(userServerUrl + "/api/v1/user/batch")
+                    .bodyValue(requestDTO)
+                    .retrieve()
+                    .bodyToMono(UserBatchApiResponse.class)
+                    .onErrorResume(WebClientResponseException.class, ex -> {
+                        if (ex.getStatusCode().is4xxClientError()) {
+                            log.warn("사용자 정보 조회 클라이언트 에러 - Status: {}, Response: {}",
+                                    ex.getStatusCode(), ex.getResponseBodyAsString());
+                            return Mono.error(ex);
+                        }
+                        log.error("사용자 정보 조회 서버 에러 - Status: {}, Response: {}",
+                                ex.getStatusCode(), ex.getResponseBodyAsString());
+                        return Mono.error(new InternalServerException(ErrorStatus.NOT_CONNECTTION_USER_DETAIL_EXCEPTION.getMessage()));
+                    })
+                    .block();
+
+            if (response == null || !response.isSuccess() || response.getData() == null) {
+                log.error("사용자 정보 조회 응답 실패");
+                throw new InternalServerException(ErrorStatus.RESPONSE_DATA_NOT_MATCH_EXCEPTION.getMessage());
+            }
+
+            // List를 Map으로 변환 (memberId를 key로)
+            Map<Long, UserBatchResponseDTO> userMap = new HashMap<>();
+            for (UserBatchResponseDTO user : response.getData()) {
+                userMap.put(user.getMemberId(), user);
+            }
+
+            log.info("사용자 정보 일괄 조회 완료 - 조회된 사용자 수: {}", userMap.size());
+            return userMap;
+
+        } catch (InternalServerException e) {
+            throw e;
+        } catch (WebClientResponseException e) {
+            log.error("사용자 정보 조회 중 WebClient 예외 - Error: {}", e.getMessage(), e);
+            throw new InternalServerException(ErrorStatus.NOT_CONNECTTION_USER_DETAIL_EXCEPTION.getMessage());
+        } catch (Exception e) {
+            log.error("사용자 정보 조회 중 예상치 못한 오류 - Error: {}", e.getMessage(), e);
+            throw new InternalServerException(ErrorStatus.CHECK_USER_DETAIL_EXCEPTION.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/com/stockmate/parts/common/response/ErrorStatus.java
+++ b/src/main/java/com/stockmate/parts/common/response/ErrorStatus.java
@@ -36,6 +36,10 @@ public enum ErrorStatus {
     /**
      * 500 SERVER_ERROR
      */
+    NOT_CONNECTTION_USER_DETAIL_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보 조회에 실패했습니다."),
+    CHECK_USER_DETAIL_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보 조회 중 오류가 발생했습니다."),
+    RESPONSE_DATA_NOT_MATCH_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "외부 서버 응답이 올바르지 않습니다."),
+    PART_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "부품을 찾을 수 없습니다."),
 
     ;
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #100

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 각 가맹점별 부품 갯수 조회 기능을 구현하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 부품 분포 조회 API: 특정 부품의 본사 보유량과 각 가맹점별 보유량을 조회할 수 있는 새로운 엔드포인트 추가

* **개선 사항**
  * 페이지네이션 정보 확장: 현재 페이지가 첫 페이지인지, 마지막 페이지인지, 다음/이전 페이지가 존재하는지를 나타내는 상태 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->